### PR TITLE
WIP. New in-memory cache for http requests #5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1880,6 +1880,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo="
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "Pablo Varela <pablovarela182@gmail.com>"
   ],
   "dependencies": {
+    "memory-cache": "^0.2.0",
     "mri": "^1.1.4",
     "path-exists": "^4.0.0",
     "require-from-string": "^2.0.2",


### PR DESCRIPTION
#5 

Manually using res.send in hanlder won't get cached by this
I need to implement again the endpoint cache to not re-render the handler

Also, try to save objects in the cache like { status: 200, body: '' }

This cache will improve requests/sec by 10x based on my experiments